### PR TITLE
Fixed signup page to use only email address

### DIFF
--- a/login/createuser.php
+++ b/login/createuser.php
@@ -1,10 +1,15 @@
+<!--
+	Author:			Christian
+	Created on:		2016 11 12
+	Last modified:	2017 11 16
+-->
 <?php
 require 'includes/functions.php';
 include_once 'config.php';
 
 //Pull username, generate new ID and hash password
 $newid = uniqid(rand(), false);
-$newuser = $_POST['newuser'];
+//$newuser = $_POST['newuser'];
 $newpw = password_hash($_POST['password1'], PASSWORD_DEFAULT);
 $pw1 = $_POST['password1'];
 $pw2 = $_POST['password2'];
@@ -34,22 +39,22 @@ if ($pw1 != $pw2) {
 
 } else {
     //Validation passed
-    if (isset($_POST['newuser']) && !empty(str_replace(' ', '', $_POST['newuser'])) && isset($_POST['password1']) && !empty(str_replace(' ', '', $_POST['password1']))) {
+    if (/*isset($_POST['newuser']) && !empty(str_replace(' ', '', $_POST['newuser'])) && */isset($_POST['password1']) && !empty(str_replace(' ', '', $_POST['password1']))) {
 
         //Tries inserting into database and add response to variable
 
         $a = new NewUserForm;
 
-        $response = $a->createUser($newuser, $newid, $newemail, $newpw);
+        $response = $a->createUser($newid, $newemail, $newpw);
 
         //Success
         if ($response == 'true') {
 
-            echo '<div class="alert alert-success"><button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'. $signupthanks .'</div><div id="returnVal" style="display:none;">true</div>';
+            echo '<div class="alert alert-success"><button type="button" onclick="redirect()" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>'. $signupthanks .'</div><div id="returnVal" style="display:none;">true</div>';
 
             //Send verification email
             $m = new MailSender;
-            $m->sendMail($newemail, $newuser, $newid, 'Verify');
+            $m->sendMail($newemail, $newid, 'Verify');
 
         } else {
             //Failure

--- a/login/globalcon.php
+++ b/login/globalcon.php
@@ -1,3 +1,8 @@
+<!--
+	Author:			Christian
+	Created on:		2016 11 12
+	Last modified:	2017 11 16
+-->
 <?php
 //SYSTEM SETTINGS
 $base_url = 'http://' . $_SERVER['SERVER_NAME'];

--- a/login/includes/functions.php
+++ b/login/includes/functions.php
@@ -1,3 +1,8 @@
+<!--
+	Author:			Christian
+	Created on:		2016 11 12
+	Last modified:	2017 11 16
+-->
 <?php
 //Class Autoloader
 spl_autoload_register(function ($className) {
@@ -59,7 +64,7 @@ function mySqlErrors($response)
     switch (substr($response, 0, 22)) {
 
         case 'Error: SQLSTATE[23000]':
-            echo "<div class=\"alert alert-danger alert-dismissable\"><button type=\"button\" class=\"close\" data-dismiss=\"alert\" aria-hidden=\"true\">&times;</button>Username or email already exists</div>";
+            echo "<div class=\"alert alert-danger alert-dismissable\"><button type=\"button\" class=\"close\" data-dismiss=\"alert\" aria-hidden=\"true\">&times;</button>Email already exists</div>";
             break;
 
         default:

--- a/login/includes/mailsender.php
+++ b/login/includes/mailsender.php
@@ -1,7 +1,12 @@
+<!--
+	Author:			Christian
+	Created on:		2016 11 12
+	Last modified:	2017 11 16
+-->
 <?php
 class MailSender
 {
-    public function sendMail($email, $user, $id, $type)
+    public function sendMail($email, $id, $type)
     {
         require 'scripts/PHPMailer/PHPMailerAutoload.php';
         include 'config.php';
@@ -26,13 +31,13 @@ class MailSender
         * CAN BE SET TO addAddress(youremail@website.com, 'Your Name') FOR PRIVATE USER APPROVAL BY MODERATOR
         * SET TO addAddress($email, $user) FOR USER SELF-VERIFICATION
         *****/
-        $mail->addAddress($email, $user);
+        $mail->addAddress($email);
 
         //Sets message body content based on type (verification or confirmation)
         if ($type == 'Verify') {
 
             //Set the subject line
-            $mail->Subject = $user . ' Account Verification';
+            $mail->Subject = ' Account Verification';
 
             //Set the body of the message
             $mail->Body = $verifymsg . '<br><a href="'.$verifyurl.'">'.$verifyurl.'</a>';

--- a/login/includes/newuserform.php
+++ b/login/includes/newuserform.php
@@ -1,17 +1,21 @@
+<!--
+	Author:			Christian
+	Created on:		2016 11 12
+	Last modified:	2017 11 16
+-->
 <?php
 class NewUserForm extends DbConn
 {
-    public function createUser($usr, $uid, $email, $pw)
+    public function createUser($uid, $email, $pw)
     {
         try {
 
             $db = new DbConn;
             $tbl_members = $db->tbl_members;
             // prepare sql and bind parameters
-            $stmt = $db->conn->prepare("INSERT INTO ".$tbl_members." (id, username, password, email)
-            VALUES (:id, :username, :password, :email)");
+            $stmt = $db->conn->prepare("INSERT INTO ".$tbl_members." (id, password, email)
+            VALUES (:id, :password, :email)");
             $stmt->bindParam(':id', $uid);
-            $stmt->bindParam(':username', $usr);
             $stmt->bindParam(':email', $email);
             $stmt->bindParam(':password', $pw);
             $stmt->execute();

--- a/login/main_login.php
+++ b/login/main_login.php
@@ -1,7 +1,7 @@
 <!--
 	Author:			Christian
 	Created on:		2016 11 12
-	Last modified:	2017 11 15
+	Last modified:	2017 11 16
 -->
 <?php
 session_start();
@@ -33,8 +33,8 @@ if (isset($_SESSION['email'])) {
         </label>
         -->
         <button name="Submit" id="submit" class="btn btn-lg btn-primary btn-block" type="submit">Sign in</button>
-	    <!--<a href="signup.php" name="Sign Up" id="signup" class="btn btn-lg btn-primary btn-block" type="submit">Create new account</a>
-		-->
+	    <a href="signup.php" name="Sign Up" id="signup" class="btn btn-lg btn-primary btn-block" type="submit">Create new account</a>
+		
         <div id="message"></div>
       </form>
 

--- a/login/signup.php
+++ b/login/signup.php
@@ -1,7 +1,12 @@
+<!--
+	Author:			Christian
+	Created on:		2016 11 12
+	Last modified:	2017 11 15
+-->
 <?php
   session_start();
 
-  if (isset($_SESSION['username'])) {
+  if (isset($_SESSION['email'])) {
       session_start();
       session_destroy();
   }
@@ -24,7 +29,7 @@
 
       <form class="form-signup" id="usersignup" name="usersignup" method="post" action="createuser.php">
         <h2 class="form-signup-heading">Register</h2>
-        <input name="newuser" id="newuser" type="text" class="form-control" placeholder="Username" autofocus>
+        <!--<input name="newuser" id="newuser" type="text" class="form-control" placeholder="Username" autofocus>-->
         <input name="email" id="email" type="text" class="form-control" placeholder="Email">
 <br>
         <input name="password1" id="password1" type="password" class="form-control" placeholder="Password">
@@ -64,6 +69,12 @@ $( "#usersignup" ).validate({
     }
   }
 });
+</script>
+
+<script>
+function redirect(){
+	window.location.replace("http://localhost/warehouse");
+}
 </script>
 
   </body>


### PR DESCRIPTION
The signup page has been changed to use only email address and added a redirection on close of the notification of a successful signup.

It is no longer needed for a username.